### PR TITLE
Add inpainting support

### DIFF
--- a/guided_diffusion/inpaintloader.py
+++ b/guided_diffusion/inpaintloader.py
@@ -1,0 +1,119 @@
+import os
+import re
+import pandas as pd
+import nibabel as nib
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import Dataset
+
+
+class InpaintVolumes(Dataset):
+    """Dataset returning MRI volumes and inpainting masks."""
+
+    def __init__(
+        self,
+        root_dir: str,
+        subset: str = "train",
+        img_size: int = 256,
+        modalities: tuple = ("T1w",),
+        normalize=None,
+    ):
+        super().__init__()
+        self.root_dir = os.path.expanduser(root_dir)
+        self.subset = subset
+        self.img_size = img_size
+        self.modalities = modalities
+        self.normalize = normalize or (lambda x: x)
+        self.cases = self._index_cases()
+
+    # ------------------------------------------------------------
+    def _index_cases(self):
+        """Collect file paths for all cases."""
+        df = pd.read_csv(f"{self.root_dir}/participants.tsv", sep="\t")
+
+        # assign train/val split for FCD subjects
+        fcd_df = df[df["group"] == "fcd"].copy()
+        fcd_df = fcd_df.sample(frac=1, random_state=42).reset_index(drop=True)
+        n_train = int(len(fcd_df) * 0.9)
+        fcd_df.loc[: n_train - 1, "split"] = "train"
+        fcd_df.loc[n_train:, "split"] = "val"
+        df.loc[fcd_df.index, "split"] = fcd_df["split"]
+
+        cases = []
+        for pid in df[(df["split"] == self.subset) & (df["group"] == "fcd")][
+            "participant_id"
+        ]:
+            case_dir = os.path.join(self.root_dir, pid, "anat")
+            files = os.listdir(case_dir)
+            img_dict = {}
+            for mod in self.modalities:
+                pattern = re.compile(rf"^{re.escape(pid)}.*{re.escape(mod)}\.nii\.gz$")
+                matches = [f for f in files if pattern.match(f)]
+                if not matches:
+                    raise FileNotFoundError(f"Missing {mod} for {pid} in {case_dir}")
+                img_dict[mod] = os.path.join(case_dir, matches[0])
+
+            mask_matches = [
+                f for f in files if re.match(rf"^{re.escape(pid)}.*roi\.nii\.gz$", f)
+            ]
+            if not mask_matches:
+                raise FileNotFoundError(f"Missing mask for {pid} in {case_dir}")
+            mask_path = os.path.join(case_dir, mask_matches[0])
+            cases.append({"img": img_dict, "mask": mask_path, "name": pid})
+        return cases
+
+    # ------------------------------------------------------------
+    def _pad_to_cube(self, vol, fill=0.0):
+        """Symmetric 3-D pad to [img_size^3]."""
+        D, H, W = vol.shape[-3:]
+        pad_D, pad_H, pad_W = (
+            self.img_size - D,
+            self.img_size - H,
+            self.img_size - W,
+        )
+        pad = (
+            pad_W // 2,
+            pad_W - pad_W // 2,
+            pad_H // 2,
+            pad_H - pad_H // 2,
+            pad_D // 2,
+            pad_D - pad_D // 2,
+        )
+        return nn.functional.pad(vol, pad, value=fill)
+
+    # ------------------------------------------------------------
+    def __getitem__(self, idx):
+        rec = self.cases[idx]
+        name = rec["name"]
+
+        vols = []
+        for mod in self.modalities:
+            arr = (
+                nib.load(rec["img"][mod]).get_fdata().astype(np.float32)
+            )
+            lo, hi = np.quantile(arr, [0.001, 0.999])
+            arr = np.clip(arr, lo, hi)
+            arr = (arr - lo) / (hi - lo + 1e-6)
+            vols.append(torch.from_numpy(arr))
+        first_mod = self.modalities[0]
+        affine = nib.load(rec["img"][first_mod]).affine
+        Y = torch.stack(vols, dim=0)
+
+        mask_arr = nib.load(rec["mask"]).get_fdata().astype(np.uint8)
+        M = torch.from_numpy(mask_arr).unsqueeze(0)
+        M = (M > 0).to(Y.dtype)
+
+        Y = self._pad_to_cube(Y, fill=0.0)
+        M = self._pad_to_cube(M, fill=0.0)
+        if self.img_size == 128:
+            pool = nn.AvgPool3d(2, 2)
+            Y = pool(Y)
+            M = pool(M)
+
+        Y_void = Y * (1 - M)
+        return Y, M, Y_void, name, affine
+
+    # ------------------------------------------------------------
+    def __len__(self):
+        return len(self.cases)

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,8 @@ GPU=0;                    # gpu to use
 SEED=42;                  # randomness seed for sampling
 CHANNELS=64;              # number of model base channels (we use 64 for all experiments)
 MODE='train';             # train vs sample
-DATASET='brats';          # brats or lidc-idri
+DATASET='brats';          # brats, lidc-idri or inpaint
+IN_CHANNELS=8;
 MODEL='ours_unet_128';    # 'ours_unet_256', 'ours_wnet_128', 'ours_wnet_256'
 
 # settings for sampling/inference
@@ -59,6 +60,12 @@ elif [[ $MODE == 'train' ]]; then
     echo "MODE: training";
     echo "Dataset: LIDC-IDRI";
     DATA_DIR=~/wdm-3d/data/LIDC-IDRI/;
+    IN_CHANNELS=8;
+  elif [[ $DATASET == 'inpaint' ]]; then
+    echo "MODE: training";
+    echo "DATASET: INPAINT";
+    DATA_DIR=~/wdm-3d/data/INPAINT/;
+    IN_CHANNELS=16;
   else
     echo "DATASET NOT FOUND -> Check the supported datasets again";
   fi
@@ -81,8 +88,8 @@ COMMON="
 --dims=3
 --batch_size=${BATCH_SIZE}
 --num_groups=32
---in_channels=8
---out_channels=8
+--in_channels=${IN_CHANNELS}
+--out_channels=${IN_CHANNELS}
 --bottleneck_attention=False
 --resample_2d=False
 --renormalize=True

--- a/scripts/generation_train.py
+++ b/scripts/generation_train.py
@@ -15,6 +15,7 @@ from guided_diffusion import (dist_util,
                               logger)
 from guided_diffusion.bratsloader import BRATSVolumes
 from guided_diffusion.lidcloader import LIDCVolumes
+from guided_diffusion.inpaintloader import InpaintVolumes
 from guided_diffusion.resample import create_named_schedule_sampler
 from guided_diffusion.script_util import (model_and_diffusion_defaults,
                                           create_model_and_diffusion,
@@ -64,13 +65,24 @@ def main():
 
     elif args.dataset == 'lidc-idri':
         assert args.image_size in [128, 256], "We currently just support image sizes: 128, 256"
-        ds = LIDCVolumes(args.data_dir, test_flag=False,
-                         normalize=(lambda x: 2*x - 1) if args.renormalize else None,
-                         mode='train',
-                         img_size=args.image_size)
+        ds = LIDCVolumes(
+            args.data_dir,
+            test_flag=False,
+            normalize=(lambda x: 2 * x - 1) if args.renormalize else None,
+            mode='train',
+            img_size=args.image_size,
+        )
+
+    elif args.dataset == 'inpaint':
+        ds = InpaintVolumes(
+            args.data_dir,
+            subset='train',
+            img_size=args.image_size,
+            normalize=(lambda x: 2 * x - 1) if args.renormalize else None,
+        )
 
     else:
-        print("We currently just support the datasets: brats, lidc-idri")
+        print("We currently just support the datasets: brats, lidc-idri, inpaint")
 
     datal = th.utils.data.DataLoader(ds,
                                      batch_size=args.batch_size,
@@ -100,7 +112,7 @@ def main():
         lr_anneal_steps=args.lr_anneal_steps,
         dataset=args.dataset,
         summary_writer=summary_writer,
-        mode='default',
+        mode='inpaint' if args.dataset == 'inpaint' else 'default',
     ).run_loop()
 
 


### PR DESCRIPTION
## Summary
- implement `InpaintVolumes` dataset for inpainting
- extend training script to use the new dataset
- support dataset in training loop and saving
- implement inpainting logic in diffusion training and sampling
- adjust run script for inpainting settings
- enable inpainting sampling from dataset

## Testing
- `python -m py_compile guided_diffusion/inpaintloader.py scripts/generation_train.py scripts/generation_sample.py guided_diffusion/train_util.py guided_diffusion/gaussian_diffusion.py`