### PR TITLE
Add pre-training checks option

### DIFF
--- a/guided_diffusion/pretrain_checks.py
+++ b/guided_diffusion/pretrain_checks.py
@@ -1,0 +1,56 @@
+import os
+import json
+import torch as th
+
+from . import dist_util, logger
+
+
+def run_pretrain_checks(args, dataloader, model, diffusion, schedule_sampler):
+    """Run a set of quick checks before starting training."""
+    logdir = logger.get_dir() or os.getcwd()
+    os.makedirs(logdir, exist_ok=True)
+
+    # Save hyperparameters
+    with open(os.path.join(logdir, "hyperparameters.json"), "w") as f:
+        json.dump(vars(args), f, indent=2)
+
+    # Fetch one batch from dataloader and save example inputs
+    sample = next(iter(dataloader))
+    if args.dataset == "inpaint":
+        example = sample[0]
+    else:
+        example = sample
+    th.save(example.cpu(), os.path.join(logdir, "example_input.pt"))
+
+    model.to(dist_util.dev([0, 1]) if len(args.devices) > 1 else dist_util.dev())
+    model.train()
+
+    cond = {}
+    if args.dataset == "inpaint":
+        cond = {"mask": sample[1].to(dist_util.dev())}
+        batch = sample[0].to(dist_util.dev())
+    else:
+        batch = sample.to(dist_util.dev())
+
+    t, _ = schedule_sampler.sample(1, dist_util.dev())
+    losses, _, _ = diffusion.training_losses(
+        model,
+        x_start=batch[:1],
+        t=t,
+        model_kwargs=cond,
+        labels=None,
+        mode="inpaint" if args.dataset == "inpaint" else "default",
+    )
+
+    loss = losses["mse_wav"].mean()
+    if not th.isfinite(loss):
+        raise RuntimeError("Non-finite loss encountered during checks")
+
+    loss.backward()
+    for p in model.parameters():
+        if p.grad is None:
+            continue
+        if not th.isfinite(p.grad).all():
+            raise RuntimeError("Non-finite gradient encountered during checks")
+
+    logger.log("Pre-training checks passed.")

--- a/scripts/generation_train.py
+++ b/scripts/generation_train.py
@@ -22,6 +22,7 @@ from guided_diffusion.script_util import (model_and_diffusion_defaults,
                                           args_to_dict,
                                           add_dict_to_argparser)
 from guided_diffusion.train_util import TrainLoop
+from guided_diffusion.pretrain_checks import run_pretrain_checks
 from torch.utils.tensorboard import SummaryWriter
 
 
@@ -104,6 +105,11 @@ def main():
                                      shuffle=True,
                                      )
 
+    if args.run_tests:
+        logger.log("Running pre-training checks...")
+        run_pretrain_checks(args, datal, model, diffusion, schedule_sampler)
+        return
+
     logger.log("Start training...")
     TrainLoop(
         model=model,
@@ -166,6 +172,7 @@ def create_argparser():
         additive_skips=False,
         use_freq=False,
         val_interval=1000,
+        run_tests=False,
     )
     defaults.update(model_and_diffusion_defaults())
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Summary
- allow optional pre-training checks with `--run_tests` flag
- new `run_pretrain_checks` helper saves hyperparams and example input then performs a forward/backward pass

## Testing
- `python -m py_compile scripts/generation_train.py guided_diffusion/pretrain_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6866d8541dc8832bb36b6c3f4357c658