### PR TITLE
Fix inpaint setup output channel mismatch

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -66,6 +66,7 @@ elif [[ $MODE == 'train' ]]; then
     echo "DATASET: INPAINT";
     DATA_DIR=~/wdm-3d/data/INPAINT/;
     IN_CHANNELS=16;
+    OUT_CHANNELS=8;
   else
     echo "DATASET NOT FOUND -> Check the supported datasets again";
   fi
@@ -89,7 +90,7 @@ COMMON="
 --batch_size=${BATCH_SIZE}
 --num_groups=32
 --in_channels=${IN_CHANNELS}
---out_channels=${IN_CHANNELS}
+--out_channels=${OUT_CHANNELS:-$IN_CHANNELS}
 --bottleneck_attention=False
 --resample_2d=False
 --renormalize=True


### PR DESCRIPTION
## Summary
- update run.sh to set out_channels=8 for the inpaint dataset
- allow run.sh to fall back to IN_CHANNELS when OUT_CHANNELS is unset

This fixes a channel mismatch between the ground truth wavelet representation (8 channels) and model output when training the inpainting mode.

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6866e7351300832ba42c7f2285b72df4