### PR TITLE
Fix example size logging in pretrain checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ We provide a script for preprocessing LIDC-IDRI. Simply run the following comman
 python utils/preproc_lidc-idri.py --dicom_dir DICOM_PATH --nifti_dir NIFTI_PATH
 ```
 
+### Image Size
+The `img_size` parameter of our dataset loaders defines the cubic size of the
+volumes returned to the model. When the raw data is larger, it is first padded
+or cropped to a cube and then downsampled to match `img_size`. For example,
+datasets stored at 256³ will be downsampled to 128³ when using
+`img_size=128`. Likewise, if your images are 128³ and you request
+`img_size=64`, the loader will return 64³ volumes.
+
 ## Evaluation
 As our code for evaluating the model performance has slightly different dependencies, we provide a second .yml file to set up the evaluation environment.
 Simply use the following command to create and activate the new environment:

--- a/guided_diffusion/bratsloader.py
+++ b/guided_diffusion/bratsloader.py
@@ -9,15 +9,23 @@ import nibabel
 
 class BRATSVolumes(torch.utils.data.Dataset):
     def __init__(self, directory, test_flag=False, normalize=None, mode='train', img_size=256):
-        '''
-        directory is expected to contain some folder structure:
-                  if some subfolder contains only files, all of these
-                  files are assumed to have a name like
-                  brats_train_NNN_XXX_123_w.nii.gz
-                  where XXX is one of t1n, t1c, t2w, t2f, seg
-                  we assume these five files belong to the same image
-                  seg is supposed to contain the segmentation
-        '''
+        """BraTS dataset loader.
+
+        Parameters
+        ----------
+        directory : str
+            Path to the dataset root directory.
+        test_flag : bool, optional
+            If ``True`` only image volumes are returned. Otherwise segmentation
+            masks are included as well.
+        normalize : callable, optional
+            Optional preprocessing function applied to the returned volume.
+        mode : str, optional
+            ``'train'`` or ``'fake'``.
+        img_size : int, optional
+            Side length of the returned cubic volume. Loaded images are padded
+            to a 256³ cube and downsampled if ``img_size`` is smaller than 256.
+        """
         super().__init__()
         self.mode = mode
         self.directory = os.path.expanduser(directory)
@@ -65,9 +73,11 @@ class BRATSVolumes(torch.utils.data.Dataset):
             image = torch.zeros(1, 256, 256, 256, dtype=torch.float32)
             image[:, 8:-8, 8:-8, 50:-51] = out
 
-            # Downsampling
-            if self.img_size == 128:
-                downsample = nn.AvgPool3d(kernel_size=2, stride=2)
+            # Downsample if necessary
+            if self.img_size != 256:
+                assert 256 % self.img_size == 0, "img_size must divide 256"
+                factor = 256 // self.img_size
+                downsample = nn.AvgPool3d(kernel_size=factor, stride=factor)
                 image = downsample(image)
         else:
             image = torch.tensor(out, dtype=torch.float32)

--- a/guided_diffusion/pretrain_checks.py
+++ b/guided_diffusion/pretrain_checks.py
@@ -20,12 +20,26 @@ def run_pretrain_checks(args, dataloader, model, diffusion, schedule_sampler):
         example = sample[0]
     else:
         example = sample
+
+    dataset_img_size = getattr(dataloader.dataset, "img_size", args.image_size)
+    expected_shape = (dataset_img_size, dataset_img_size, dataset_img_size)
+    actual_shape = tuple(example.shape[-3:])
+    if actual_shape != expected_shape:
+        logger.log(
+            f"Warning: example volume shape {actual_shape} does not match dataset image_size {expected_shape}"
+        )
     th.save(example.cpu(), os.path.join(logdir, "example_input.pt"))
 
     model.to(dist_util.dev([0, 1]) if len(args.devices) > 1 else dist_util.dev())
     model.train()
 
     cond = {}
+    if args.dataset == "inpaint":
+        cond = {"mask": sample[1].to(dist_util.dev())}
+        batch = sample[0].to(dist_util.dev())
+    else:
+        batch = sample.to(dist_util.dev())
+
     def to_cpu(obj):
         if th.is_tensor(obj):
             return obj.cpu()
@@ -34,8 +48,6 @@ def run_pretrain_checks(args, dataloader, model, diffusion, schedule_sampler):
         if isinstance(obj, dict):
             return {k: to_cpu(v) for k, v in obj.items()}
         return obj
-
-    th.save(to_cpu(sample), os.path.join(logdir, "example_input.pt"))
 
     t, _ = schedule_sampler.sample(1, dist_util.dev())
     losses, _, _ = diffusion.training_losses(


### PR DESCRIPTION
## Summary
- check that the fetched sample matches `dataloader.dataset.img_size`
- clarify dataset `img_size` handling and add general downsampling logic
- document how `img_size` controls volume size

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867c64f7144832b89bfc709807d01ef