### PR TITLE
Fix inpainting loader padding

### DIFF
--- a/guided_diffusion/inpaintloader.py
+++ b/guided_diffusion/inpaintloader.py
@@ -20,6 +20,10 @@ class InpaintVolumes(Dataset):
     img_size : int, optional
         Final side length of the returned volumes. Loaded data is padded to the
         largest dimension and downsampled to ``img_size`` if necessary.
+    desired_image_size : int, optional
+        Volumes are padded to this side length before downsampling. If ``None``,
+        ``img_size`` or the largest volume dimension is used. Must be divisible
+        by ``img_size``.
     modalities : tuple, optional
         MRI modalities to load.
     normalize : callable, optional
@@ -33,6 +37,7 @@ class InpaintVolumes(Dataset):
         root_dir: str,
         subset: str = "train",
         img_size: int = 256,
+        desired_image_size: int | None = None,
         modalities: tuple = ("T1w",),
         normalize=None,
         cache: bool = False,
@@ -41,6 +46,11 @@ class InpaintVolumes(Dataset):
         self.root_dir = os.path.expanduser(root_dir)
         self.subset = subset
         self.img_size = img_size
+        self.desired_image_size = desired_image_size
+        if self.desired_image_size is not None:
+            assert (
+                self.desired_image_size % self.img_size == 0
+            ), "img_size must divide desired_image_size"
         self.modalities = modalities
         self.normalize = normalize or (lambda x: x)
         self.cases = self._index_cases()
@@ -126,11 +136,17 @@ class InpaintVolumes(Dataset):
         M = torch.tensor(mask_arr, dtype=torch.float32).unsqueeze(0)
         M = (M > 0).to(Y.dtype)
 
-        target_size = max(max(Y.shape[-3:]), self.img_size)
+        target_size = max(
+            max(Y.shape[-3:]),
+            self.desired_image_size if self.desired_image_size is not None else self.img_size,
+        )
+        assert (
+            target_size % self.img_size == 0
+        ), "img_size must divide the padded size"
+
         Y = self._pad_to_cube(Y, target_size, fill=0.0)
         M = self._pad_to_cube(M, target_size, fill=0.0)
         if target_size != self.img_size:
-            assert target_size % self.img_size == 0, "img_size must divide the padded size"
             factor = target_size // self.img_size
             pool = nn.AvgPool3d(factor, factor)
             Y = pool(Y)

--- a/run.sh
+++ b/run.sh
@@ -46,6 +46,12 @@ else
   echo "MODEL TYPE NOT FOUND -> Check the supported configurations again";
 fi
 
+# ensure volumes are padded to a size divisible by the image size
+DESIRED_IMAGE_SIZE=$IMAGE_SIZE
+if [[ $IMAGE_SIZE -eq 128 ]]; then
+  DESIRED_IMAGE_SIZE=256
+fi
+
 # some information and overwriting batch size for sampling
 # (overwrite in case you want to sample with a higher batch size)
 # no need to change for reproducing
@@ -105,6 +111,7 @@ TRAIN="
 --resume_checkpoint=
 --resume_step=0
 --image_size=${IMAGE_SIZE}
+--desired_image_size=${DESIRED_IMAGE_SIZE}
 --use_fp16=False
 --lr=1e-5
 --save_interval=100000
@@ -116,6 +123,7 @@ SAMPLE="
 --data_mode=${DATA_MODE}
 --seed=${SEED}
 --image_size=${IMAGE_SIZE}
+--desired_image_size=${DESIRED_IMAGE_SIZE}
 --use_fp16=False
 --model_path=./${RUN_DIR}/checkpoints/${DATASET}_${ITERATIONS}000.pt
 --devices=${GPU}

--- a/scripts/generation_sample.py
+++ b/scripts/generation_sample.py
@@ -58,7 +58,12 @@ def main():
     dwt = DWT_3D("haar")
 
     if args.dataset == 'inpaint':
-        ds = InpaintVolumes(args.data_dir, subset='val', img_size=args.image_size)
+        ds = InpaintVolumes(
+            args.data_dir,
+            subset='val',
+            img_size=args.image_size,
+            desired_image_size=args.desired_image_size,
+        )
         loader = th.utils.data.DataLoader(ds, batch_size=args.batch_size, shuffle=False)
         data_iter = iter(loader)
     else:
@@ -157,6 +162,7 @@ def create_argparser():
         mode='default',
         renormalize=False,
         image_size=256,
+        desired_image_size=None,
         half_res_crop=False,
         concat_coords=False, # if true, add 3 (for 3d) or 2 (for 2d) to in_channels
     )

--- a/scripts/generation_train.py
+++ b/scripts/generation_train.py
@@ -85,6 +85,7 @@ def main():
             args.data_dir,
             subset='train',
             img_size=args.image_size,
+            desired_image_size=args.desired_image_size,
             normalize=(lambda x: 2 * x - 1) if args.renormalize else None,
             cache=args.cache_dataset,
         )
@@ -92,6 +93,7 @@ def main():
             args.data_dir,
             subset='val',
             img_size=args.image_size,
+            desired_image_size=args.desired_image_size,
             normalize=(lambda x: 2 * x - 1) if args.renormalize else None,
             cache=args.cache_dataset,
         )
@@ -180,6 +182,7 @@ def create_argparser():
         val_interval=1000,
         run_tests=True,
         cache_dataset=True,
+        desired_image_size=None,
     )
     defaults.update(model_and_diffusion_defaults())
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Summary
- add configurable desired padding size in the inpainting dataset
- expose `--desired_image_size` arg in training and sampling scripts
- allow specifying `DESIRED_IMAGE_SIZE` in `run.sh`

## Testing
- `bash run.sh` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6867d9818c98832bb090cd2baf337b93