### PR TITLE
Enable dataset downsampling configuration

### DIFF
--- a/guided_diffusion/inpaintloader.py
+++ b/guided_diffusion/inpaintloader.py
@@ -138,24 +138,17 @@ class InpaintVolumes(Dataset):
         M = torch.tensor(mask_arr, dtype=torch.float32).unsqueeze(0)
         M = (M > 0).to(Y.dtype)
        
-        target_size = max(
-            max(Y.shape[-3:]),
-            self.desired_image_size if self.desired_image_size is not None else self.img_size,
-        )
-        assert (
-            target_size % self.img_size == 0
-        ), "img_size must divide the padded size"
-
         target_size = max(max(Y.shape[-3:]), self.img_size)
-        if target_size % self.desired_image_size != 0:
-            target_size = (
-                (target_size + self.desired_image_size - 1)
-                // self.desired_image_size
-            ) * self.desired_image_size
+        if self.desired_image_size is not None:
+            if target_size % self.desired_image_size != 0:
+                target_size = (
+                    (target_size + self.desired_image_size - 1)
+                    // self.desired_image_size
+                ) * self.desired_image_size
 
         Y = self._pad_to_cube(Y, target_size, fill=0.0)
         M = self._pad_to_cube(M, target_size, fill=0.0)
-        if target_size != self.desired_image_size:
+        if self.desired_image_size is not None and target_size != self.desired_image_size:
             factor = target_size // self.desired_image_size
             pool = nn.AvgPool3d(factor, factor)
             Y = pool(Y)

--- a/run.sh
+++ b/run.sh
@@ -46,6 +46,8 @@ else
   echo "MODEL TYPE NOT FOUND -> Check the supported configurations again";
 fi
 
+# dataset volume size; override to change
+DATASET_IMAGE_SIZE=${DATASET_IMAGE_SIZE:-$IMAGE_SIZE}
 # final side length after downsampling; override to change
 DESIRED_IMAGE_SIZE=${DESIRED_IMAGE_SIZE:-$IMAGE_SIZE}
 
@@ -108,6 +110,7 @@ TRAIN="
 --resume_checkpoint=
 --resume_step=0
 --image_size=${IMAGE_SIZE}
+--dataset_image_size=${DATASET_IMAGE_SIZE}
 --desired_image_size=${DESIRED_IMAGE_SIZE}
 --use_fp16=False
 --lr=1e-5
@@ -120,6 +123,7 @@ SAMPLE="
 --data_mode=${DATA_MODE}
 --seed=${SEED}
 --image_size=${IMAGE_SIZE}
+--dataset_image_size=${DATASET_IMAGE_SIZE}
 --desired_image_size=${DESIRED_IMAGE_SIZE}
 --use_fp16=False
 --model_path=./${RUN_DIR}/checkpoints/${DATASET}_${ITERATIONS}000.pt

--- a/scripts/generation_sample.py
+++ b/scripts/generation_sample.py
@@ -57,11 +57,12 @@ def main():
     idwt = IDWT_3D("haar")
     dwt = DWT_3D("haar")
 
+    dataset_size = args.dataset_image_size or args.image_size
     if args.dataset == 'inpaint':
         ds = InpaintVolumes(
             args.data_dir,
             subset='val',
-            img_size=args.image_size,
+            img_size=dataset_size,
             desired_image_size=args.desired_image_size,
         )
         loader = th.utils.data.DataLoader(ds, batch_size=args.batch_size, shuffle=False)
@@ -163,6 +164,7 @@ def create_argparser():
         renormalize=False,
         image_size=256,
         desired_image_size=None,
+        dataset_image_size=None,
         half_res_crop=False,
         concat_coords=False, # if true, add 3 (for 3d) or 2 (for 2d) to in_channels
     )

--- a/scripts/generation_train.py
+++ b/scripts/generation_train.py
@@ -57,6 +57,7 @@ def main():
     model.to(dist_util.dev([0, 1]) if len(args.devices) > 1 else dist_util.dev())  # allow for 2 devices
     schedule_sampler = create_named_schedule_sampler(args.schedule_sampler, diffusion,  maxt=1000)
 
+    dataset_size = args.dataset_image_size or args.image_size
     if args.dataset == 'brats':
         assert args.image_size in [128, 256], "We currently just support image sizes: 128, 256"
         ds = BRATSVolumes(
@@ -64,7 +65,7 @@ def main():
             test_flag=False,
             normalize=(lambda x: 2*x - 1) if args.renormalize else None,
             mode='train',
-            img_size=args.image_size,
+            img_size=dataset_size,
             cache=args.cache_dataset,
         )
         val_loader = None
@@ -76,7 +77,7 @@ def main():
             test_flag=False,
             normalize=(lambda x: 2 * x - 1) if args.renormalize else None,
             mode='train',
-            img_size=args.image_size,
+            img_size=dataset_size,
         )
         val_loader = None
 
@@ -84,7 +85,7 @@ def main():
         ds = InpaintVolumes(
             args.data_dir,
             subset='train',
-            img_size=args.image_size,
+            img_size=dataset_size,
             desired_image_size=args.desired_image_size,
             normalize=(lambda x: 2 * x - 1) if args.renormalize else None,
             cache=args.cache_dataset,
@@ -92,7 +93,7 @@ def main():
         val_ds = InpaintVolumes(
             args.data_dir,
             subset='val',
-            img_size=args.image_size,
+            img_size=dataset_size,
             desired_image_size=args.desired_image_size,
             normalize=(lambda x: 2 * x - 1) if args.renormalize else None,
             cache=args.cache_dataset,
@@ -183,6 +184,7 @@ def create_argparser():
         run_tests=True,
         cache_dataset=True,
         desired_image_size=None,
+        dataset_image_size=None,
     )
     defaults.update(model_and_diffusion_defaults())
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Summary
- introduce `dataset_image_size` argument in train and sample scripts
- adjust inpaint dataset loader for flexible downsampling
- allow run.sh to specify dataset size separately from model size

## Testing
- `python -m py_compile scripts/generation_train.py scripts/generation_sample.py guided_diffusion/inpaintloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6867ea703b5c832ba02a3263e7aa5a3d