### PR TITLE
Fix CLI argument types for dataset sizing

### DIFF
--- a/scripts/generation_sample.py
+++ b/scripts/generation_sample.py
@@ -163,14 +163,14 @@ def create_argparser():
         mode='default',
         renormalize=False,
         image_size=256,
-        desired_image_size=None,
-        dataset_image_size=None,
         half_res_crop=False,
         concat_coords=False, # if true, add 3 (for 3d) or 2 (for 2d) to in_channels
     )
     defaults.update({k:v for k, v in model_and_diffusion_defaults().items() if k not in defaults})
     parser = argparse.ArgumentParser()
     add_dict_to_argparser(parser, defaults)
+    parser.add_argument("--desired_image_size", type=int, default=None)
+    parser.add_argument("--dataset_image_size", type=int, default=None)
     return parser
 
 

--- a/scripts/generation_train.py
+++ b/scripts/generation_train.py
@@ -183,12 +183,12 @@ def create_argparser():
         val_interval=1000,
         run_tests=True,
         cache_dataset=True,
-        desired_image_size=None,
-        dataset_image_size=None,
     )
     defaults.update(model_and_diffusion_defaults())
     parser = argparse.ArgumentParser()
     add_dict_to_argparser(parser, defaults)
+    parser.add_argument("--desired_image_size", type=int, default=None)
+    parser.add_argument("--dataset_image_size", type=int, default=None)
     return parser
 
 


### PR DESCRIPTION
## Summary
- parse `desired_image_size` and `dataset_image_size` as integers

## Testing
- `bash run.sh` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6867ec22c6c0832b82dcb7528d63c48f