### PR TITLE
Improve dataset loading with caching

### DIFF
--- a/scripts/generation_train.py
+++ b/scripts/generation_train.py
@@ -78,6 +78,7 @@ def main():
             normalize=(lambda x: 2 * x - 1) if args.renormalize else None,
             mode='train',
             img_size=dataset_size,
+            cache=args.cache_dataset,
         )
         val_loader = None
 


### PR DESCRIPTION
## Summary
- add optional caching to `BRATSVolumes` and `LIDCVolumes`
- pass cache flag through `generation_train.py`

## Testing
- `python -m py_compile guided_diffusion/bratsloader.py guided_diffusion/lidcloader.py scripts/generation_train.py`
- `python -m py_compile guided_diffusion/inpaintloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6868455f4e3c832baa740665436edc5c