### PR TITLE
Fix argparse conflict for early stopping flags

### DIFF
--- a/scripts/generation_train.py
+++ b/scripts/generation_train.py
@@ -187,8 +187,6 @@ def create_argparser():
         val_interval=1000,
         run_tests=False,
         cache_dataset=True,
-        early_stopping=False,
-        early_stopping_patience=10,
     )
     defaults.update(model_and_diffusion_defaults())
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Summary
- remove `early_stopping` args from defaults to avoid argparse duplication

## Testing
- `bash run_search.sh` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68693df429f8832b994eee5195e4e3eb